### PR TITLE
Do not extend the base controller class.

### DIFF
--- a/src/Ayaline/Bundle/ComposerBundle/Controller/ComposerController.php
+++ b/src/Ayaline/Bundle/ComposerBundle/Controller/ComposerController.php
@@ -12,14 +12,13 @@
 namespace Ayaline\Bundle\ComposerBundle\Controller;
 
 use Sonata\NotificationBundle\Backend\AMQPBackendDispatcher;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 
-class ComposerController extends Controller
+class ComposerController
 {
     /**
      * @var EngineInterface


### PR DESCRIPTION
Since the controller is registered as a service and all the dependencies are injected, there is no need to extend the base Controller class.
