### PR TITLE
prevent browser to check spellcheck in textarea

### DIFF
--- a/src/Ayaline/Bundle/ComposerBundle/Form/ComposerType.php
+++ b/src/Ayaline/Bundle/ComposerBundle/Form/ComposerType.php
@@ -42,6 +42,7 @@ DCB;
                     'attr' => array(
                         'class' => 'form-control',
                         'rows' => 15,
+                        'spellcheck'=> false
                     ),
                     'data' => $this->defaultComposerBody,
                     'constraints' => array(


### PR DESCRIPTION
This doesn't make any sense but It is good to have a better UI.