### PR TITLE
Improve textarea resizing

### DIFF
--- a/src/Ayaline/Bundle/ComposerBundle/Resources/public/css/main.css
+++ b/src/Ayaline/Bundle/ComposerBundle/Resources/public/css/main.css
@@ -66,7 +66,8 @@ html.draganddrop textarea {
     border-bottom: 1px dashed #ddd;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-    display: block
+    display: block;
+    max-width: 100%;
 }
 
 .dragover textarea, .dragover .drag-and-drop {


### PR DESCRIPTION
Resizing the textarea should be restricted to the height of the textarea. Setting the textarea's max-width to 100% implements this requirement.